### PR TITLE
Fix max eventlisteners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juit/pgproxy-monorepo",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juit/pgproxy-monorepo",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "workspaces": [
         "workspaces/pool",
@@ -22,8 +22,8 @@
       ],
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241106.0",
-        "@plugjs/build": "^0.6.14",
-        "@plugjs/tsd": "^0.6.21",
+        "@plugjs/build": "^0.6.15",
+        "@plugjs/tsd": "^0.6.22",
         "@types/ini": "^4.1.1",
         "@types/libpq": "^1.8.13",
         "@types/node": "<20",
@@ -741,9 +741,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
-      "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -935,56 +935,56 @@
       }
     },
     "node_modules/@plugjs/build": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/@plugjs/build/-/build-0.6.14.tgz",
-      "integrity": "sha512-68ifAAYz8cepvCxQft2E4nxvJoifhLXHXLnNfg9cIw8brSN9D+A+VHKWmS6F1uL03Df4UEHg1sghPk9PHa2glw==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@plugjs/build/-/build-0.6.15.tgz",
+      "integrity": "sha512-l22Cl8OLzh5f7WqR91bp3JhR6e65Vb1ccnET/iLih0v9xTVlVYLAYocQ8WWWKEgqssVBDV8FVRIn9vRcxEz5Qg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "bootstrap-plugjs-build": "dist/bootstrap.mjs"
       },
       "peerDependencies": {
-        "@plugjs/cov8": "^0.6.21",
-        "@plugjs/eslint": "^0.6.21",
-        "@plugjs/eslint-plugin": "^0.2.24",
-        "@plugjs/expect5": "^0.6.21",
-        "@plugjs/plug": "^0.6.21",
-        "@plugjs/typescript": "^0.6.21"
+        "@plugjs/cov8": "^0.6.22",
+        "@plugjs/eslint": "^0.6.22",
+        "@plugjs/eslint-plugin": "^0.2.25",
+        "@plugjs/expect5": "^0.6.22",
+        "@plugjs/plug": "^0.6.22",
+        "@plugjs/typescript": "^0.6.22"
       }
     },
     "node_modules/@plugjs/cov8": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@plugjs/cov8/-/cov8-0.6.21.tgz",
-      "integrity": "sha512-ZPQ2Qji0kDpvQhAlvCUEqTYOf5/Qt+AwvEeI7cfBq7sd3mtZlUglJx2RFimETAGdR3vfbAWyFiPNo2b6s6TmyQ==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@plugjs/cov8/-/cov8-0.6.22.tgz",
+      "integrity": "sha512-yHhqGp8WusfGXNzZOdoKvI5GVX9/7PfkmTn1+EecaVaOSNaSyWTiCIjVNkUDQmrQbcW3qIiX+0bxsVlvvuckbg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.26.2",
         "@babel/types": "^7.26.0",
-        "@plugjs/cov8-html": "^0.1.91",
-        "@plugjs/tsrun": "^0.5.47",
+        "@plugjs/cov8-html": "^0.1.92",
+        "@plugjs/tsrun": "^0.5.48",
         "source-map": "^0.7.4"
       },
       "bin": {
         "cov8": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.21"
+        "@plugjs/plug": "0.6.22"
       }
     },
     "node_modules/@plugjs/cov8-html": {
-      "version": "0.1.91",
-      "resolved": "https://registry.npmjs.org/@plugjs/cov8-html/-/cov8-html-0.1.91.tgz",
-      "integrity": "sha512-Um1ThZW68xP8UArueKWzW0dvHS4fNbk+a5/epHToKoZm1HpYqR7K2CiZBVXyqndNIdlChZJaHRfzVgtbQAM3lg==",
+      "version": "0.1.92",
+      "resolved": "https://registry.npmjs.org/@plugjs/cov8-html/-/cov8-html-0.1.92.tgz",
+      "integrity": "sha512-TFbk8Pltv/Rjuhma1QgNy6U8qs9kDPj5KIwaLF2uVxTYLl709FuPLT17w2QR6/ZUzV+fmC6C4SLM0XQ/wJXmmw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@plugjs/eslint": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@plugjs/eslint/-/eslint-0.6.21.tgz",
-      "integrity": "sha512-FIlcau4NAJ+FDbn26TQOHPOQzt9kUFU5HsVg3RC0M0kFwZsp2aRjVqdFCy68Kqq1xvcuat7B5nGjP9gzEsbACg==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@plugjs/eslint/-/eslint-0.6.22.tgz",
+      "integrity": "sha512-NomtwaJB9yxE6KifSsHB1866P1Qe/Q7gtgxpiMBDXIauL31Il3QSi+Lj1wowo6uW4aZbljtM9n4XgLoIX67alw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -992,24 +992,24 @@
         "eslint": "9.5.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.21"
+        "@plugjs/plug": "0.6.22"
       }
     },
     "node_modules/@plugjs/eslint-plugin": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@plugjs/eslint-plugin/-/eslint-plugin-0.2.24.tgz",
-      "integrity": "sha512-8EKQpuYCN/Ii6t3rgZeiM/2hhQ9pi+pzE2IY9QXusrQoIaOOMl8sWYHu1W/ANiEQ4Fj5IKX9fYK05/aU1DQHDg==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@plugjs/eslint-plugin/-/eslint-plugin-0.2.25.tgz",
+      "integrity": "sha512-KWH/hXrCAsrHMusjCPNSukCtRvRKvHlstuKdQt4OibJm5hIPgq9h6wWEMzeJQn2nIuTccrZAhmy6wqhOFbmLTA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/js": "9.13.0",
+        "@eslint/js": "9.14.0",
         "@nolyfill/is-core-module": "1.0.39",
-        "@typescript-eslint/utils": "8.12.2",
+        "@typescript-eslint/utils": "8.13.0",
         "debug": "4.3.7",
         "doctrine": "3.0.0",
         "enhanced-resolve": "5.17.1",
-        "eslint": "9.13.0",
+        "eslint": "9.14.0",
         "eslint-module-utils": "2.12.0",
         "eslint-plugin-unicorn": "56.0.0",
         "eslint-visitor-keys": "4.2.0",
@@ -1017,7 +1017,7 @@
         "estraverse": "5.3.0",
         "fast-glob": "3.3.2",
         "get-tsconfig": "4.8.1",
-        "globals": "15.11.0",
+        "globals": "15.12.0",
         "is-bun-module": "1.2.1",
         "is-core-module": "2.15.1",
         "is-glob": "4.0.3",
@@ -1028,10 +1028,10 @@
         "stable-hash": "0.0.4",
         "tslib": "2.8.1",
         "typescript": "5.6.3",
-        "typescript-eslint": "8.12.2"
+        "typescript-eslint": "8.13.0"
       },
       "peerDependencies": {
-        "eslint": "^9.13.0"
+        "eslint": "^9.14.0"
       }
     },
     "node_modules/@plugjs/eslint-plugin/node_modules/@eslint/config-array": {
@@ -1064,6 +1064,21 @@
         "node": "*"
       }
     },
+    "node_modules/@plugjs/eslint-plugin/node_modules/@humanwhocodes/retry": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@plugjs/eslint-plugin/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1077,23 +1092,23 @@
       }
     },
     "node_modules/@plugjs/eslint-plugin/node_modules/eslint": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
-      "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.18.0",
         "@eslint/core": "^0.7.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.13.0",
+        "@eslint/js": "9.14.0",
         "@eslint/plugin-kit": "^0.2.0",
-        "@humanfs/node": "^0.16.5",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.1",
+        "@humanwhocodes/retry": "^0.4.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -1101,9 +1116,9 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.1.0",
-        "eslint-visitor-keys": "^4.1.0",
-        "espree": "^10.2.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1153,29 +1168,29 @@
       }
     },
     "node_modules/@plugjs/expect5": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@plugjs/expect5/-/expect5-0.6.21.tgz",
-      "integrity": "sha512-2XiZALRx3hMYve45BCi2sFTEZhXSp7iR0MD5Kitn6fWE/Uekm/PIv52ycMgqMneaXmOFFHl2d4jiZ75jQzXONw==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@plugjs/expect5/-/expect5-0.6.22.tgz",
+      "integrity": "sha512-dp6/pG+D5B5buPT0s2Uclv5ILLq6IoQMLbXITTd1jZ9rK2AFeiSL3r5dGLbwjOu1AcI9ZMt/2QRRXUaRWsRBPw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@plugjs/tsrun": "^0.5.47"
+        "@plugjs/tsrun": "^0.5.48"
       },
       "bin": {
         "expect5": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.21"
+        "@plugjs/plug": "0.6.22"
       }
     },
     "node_modules/@plugjs/plug": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@plugjs/plug/-/plug-0.6.21.tgz",
-      "integrity": "sha512-gJUOtbljzEVFQrT1viqAnEARnqeaE+L4gJeHzzcnNoZe7mDR1E5dPvqQ43+dNiBv2FQjBVJtM5wc+oP0f6LZMQ==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@plugjs/plug/-/plug-0.6.22.tgz",
+      "integrity": "sha512-/jBIHlVBSVD8RcmUyorV3mzW4JfIrgyG/f/Q6on9Wz0WhhHABUxOZAXDM5UjzqDUEA8LedzN49j58ynYyBN0Pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@plugjs/tsrun": "^0.5.47",
+        "@plugjs/tsrun": "^0.5.48",
         "@types/node": "<19",
         "esbuild": "^0.24.0",
         "jsonc-parser": "^3.3.1",
@@ -1186,22 +1201,22 @@
       }
     },
     "node_modules/@plugjs/tsd": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@plugjs/tsd/-/tsd-0.6.21.tgz",
-      "integrity": "sha512-DAcvAC9kPD7ykWUBnk7ui8qWxr1LYNuWr+4SRt2EsXeDaMhS74Eu/Ppghi+sS2zhDb0LSdnlUZAwmhPcIo6G9g==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@plugjs/tsd/-/tsd-0.6.22.tgz",
+      "integrity": "sha512-x73anvyfQuy5yMCzg/0zT00ESwYPJAedpeg+3hf42wexwIx1f1xySANwXKraQs8URFoQsQD9SFNPqsqR8cwyBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tsd": "^0.31.2"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.21"
+        "@plugjs/plug": "0.6.22"
       }
     },
     "node_modules/@plugjs/tsrun": {
-      "version": "0.5.47",
-      "resolved": "https://registry.npmjs.org/@plugjs/tsrun/-/tsrun-0.5.47.tgz",
-      "integrity": "sha512-BZiDSEDDaNzRbpC9DP2T1jKbCHOuQ4crfIDadK5rjEHw/tgZxzFpNuqtAaCBeh/f6uuRV/OWyjazBDODf1SKlQ==",
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/@plugjs/tsrun/-/tsrun-0.5.48.tgz",
+      "integrity": "sha512-9iuyVhawWnVsW0Gfl7h1knv++9VA9hZUObplgLBlzxoPmolTax6DfefSK7ejMKUvE9QLPQZcrnKEHHXBEY7fYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "^0.24.0"
@@ -1211,9 +1226,9 @@
       }
     },
     "node_modules/@plugjs/typescript": {
-      "version": "0.6.21",
-      "resolved": "https://registry.npmjs.org/@plugjs/typescript/-/typescript-0.6.21.tgz",
-      "integrity": "sha512-8fCSLApa3/50DMBnXDDNuzYKqHhLWI7jDYsG2fV57Zc5xqUd7TWInGNWLUYEYfo4Blo9XzqiyjR14NyQg8O92w==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@plugjs/typescript/-/typescript-0.6.22.tgz",
+      "integrity": "sha512-b3j3XFL/3dTr+RB6/4TKQL1Jw02ZDyASOvRC91SPZMAA/8D8zMSqyGOxdnDnYIQmiHUKZUb5nIb9NM4h3y9efQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1221,7 +1236,7 @@
         "typescript": "^5.6.3"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.21"
+        "@plugjs/plug": "0.6.22"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1324,18 +1339,18 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.12.2.tgz",
-      "integrity": "sha512-gQxbxM8mcxBwaEmWdtLCIGLfixBMHhQjBqR8sVWNTPpcj45WlYL2IObS/DNMLH1DBP0n8qz+aiiLTGfopPEebw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.13.0.tgz",
+      "integrity": "sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.12.2",
-        "@typescript-eslint/type-utils": "8.12.2",
-        "@typescript-eslint/utils": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2",
+        "@typescript-eslint/scope-manager": "8.13.0",
+        "@typescript-eslint/type-utils": "8.13.0",
+        "@typescript-eslint/utils": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1359,17 +1374,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.12.2.tgz",
-      "integrity": "sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
+      "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.12.2",
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/typescript-estree": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2",
+        "@typescript-eslint/scope-manager": "8.13.0",
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/typescript-estree": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1389,15 +1404,15 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.2.tgz",
-      "integrity": "sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.13.0.tgz",
+      "integrity": "sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2"
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1408,15 +1423,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.12.2.tgz",
-      "integrity": "sha512-bwuU4TAogPI+1q/IJSKuD4shBLc/d2vGcRT588q+jzayQyjVK2X6v/fbR4InY2U2sgf8MEvVCqEWUzYzgBNcGQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.13.0.tgz",
+      "integrity": "sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.12.2",
-        "@typescript-eslint/utils": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.13.0",
+        "@typescript-eslint/utils": "8.13.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -1434,9 +1449,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.2.tgz",
-      "integrity": "sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.13.0.tgz",
+      "integrity": "sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1449,15 +1464,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.2.tgz",
-      "integrity": "sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.13.0.tgz",
+      "integrity": "sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/visitor-keys": "8.12.2",
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/visitor-keys": "8.13.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1479,17 +1494,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.2.tgz",
-      "integrity": "sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.13.0.tgz",
+      "integrity": "sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.12.2",
-        "@typescript-eslint/types": "8.12.2",
-        "@typescript-eslint/typescript-estree": "8.12.2"
+        "@typescript-eslint/scope-manager": "8.13.0",
+        "@typescript-eslint/types": "8.13.0",
+        "@typescript-eslint/typescript-estree": "8.13.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1503,14 +1518,14 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.2.tgz",
-      "integrity": "sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.13.0.tgz",
+      "integrity": "sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/types": "8.13.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1790,9 +1805,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001678",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001678.tgz",
-      "integrity": "sha512-RR+4U/05gNtps58PEBDZcPWTgEO2MBeoPZ96aQcjmfkBWRIDfN451fW2qyDA9/+HohLLIL5GqiMwA+IB1pWarw==",
+      "version": "1.0.30001679",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz",
+      "integrity": "sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==",
       "dev": true,
       "funding": [
         {
@@ -2043,9 +2058,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.54",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.54.tgz",
-      "integrity": "sha512-TX6vHleisn5i/4pekTyy1sdoLXQNy8VFvBK/fJRXSyp7GUO27KioLTG0Qo5wFjM3ZF4ryKinDo4m+IJ+rwUWSw==",
+      "version": "1.5.55",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.55.tgz",
+      "integrity": "sha512-6maZ2ASDOTBtjt9FhqYPRnbvKU5tjG0IN9SztUOWYw2AzNDNpKJYLJmlK0/En4Hs/aiWnB+JZ+gW19PIGszgKg==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -2609,9 +2624,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.11.0.tgz",
-      "integrity": "sha512-yeyNSjdbyVaWurlwCpcA6XNBrHTMIeDdj0/hnvX/OLJ9ekOXYbLsLinH/MucQyGvNnXhidTdNhTtJaffL2sMfw==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
+      "integrity": "sha512-1+gLErljJFhbOVyaetcwJiJ4+eLe45S2E7P5UiZ9xGfeq3ATQf5DOv9G7MH3gGbKQLkzmNh2DxfZwLdw+j6oTQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3002,9 +3017,9 @@
       "license": "MIT"
     },
     "node_modules/justus": {
-      "version": "0.5.54",
-      "resolved": "https://registry.npmjs.org/justus/-/justus-0.5.54.tgz",
-      "integrity": "sha512-XlEH3M27ny7KOw69tQjNNq+t219RSIerkIQEQAQVqGzt3vKsJoPHV2oD/nsr70dA7UWh7RQWettI7JB8XWqslA==",
+      "version": "0.5.55",
+      "resolved": "https://registry.npmjs.org/justus/-/justus-0.5.55.tgz",
+      "integrity": "sha512-dPKofhm3i01LJj71/hg5EbYYsWVB/LfNvYPoq3noXplJXlAlXTtq9ZBtDc5ZA/snFmsgKKwtxOnAUK5yE2Vp9w==",
       "license": "Apache-2.0"
     },
     "node_modules/keyv": {
@@ -3196,16 +3211,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/merge2": {
@@ -4179,16 +4184,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.12.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.12.2.tgz",
-      "integrity": "sha512-UbuVUWSrHVR03q9CWx+JDHeO6B/Hr9p4U5lRH++5tq/EbFq1faYZe50ZSBePptgfIKLEti0aPQ3hFgnPVcd8ZQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.13.0.tgz",
+      "integrity": "sha512-vIMpDRJrQd70au2G8w34mPps0ezFSPMEX4pXkTzUkrNbRX+36ais2ksGWN0esZL+ZMaFJEneOBHzCgSqle7DHw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.12.2",
-        "@typescript-eslint/parser": "8.12.2",
-        "@typescript-eslint/utils": "8.12.2"
+        "@typescript-eslint/eslint-plugin": "8.13.0",
+        "@typescript-eslint/parser": "8.13.0",
+        "@typescript-eslint/utils": "8.13.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4350,12 +4355,13 @@
       "license": "ISC"
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {
@@ -4374,65 +4380,72 @@
     },
     "workspaces/cli": {
       "name": "@juit/pgproxy-cli",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-server": "1.1.8",
+        "@juit/pgproxy-server": "1.1.9",
         "dotenv": "^16.4.5",
         "ini": "^5.0.0",
-        "justus": "^0.5.54",
+        "justus": "^0.5.55",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
         "pgproxy-server": "dist/cli.mjs"
       }
     },
+    "workspaces/cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "workspaces/client": {
       "name": "@juit/pgproxy-client",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-types": "1.1.8"
+        "@juit/pgproxy-types": "1.1.9"
       }
     },
     "workspaces/client-node": {
       "name": "@juit/pgproxy-client-node",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.1.8",
+        "@juit/pgproxy-client": "1.1.9",
         "undici": "^6.20.1"
       }
     },
     "workspaces/client-psql": {
       "name": "@juit/pgproxy-client-psql",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.1.8",
-        "@juit/pgproxy-pool": "1.1.8"
+        "@juit/pgproxy-client": "1.1.9",
+        "@juit/pgproxy-pool": "1.1.9"
       }
     },
     "workspaces/client-whatwg": {
       "name": "@juit/pgproxy-client-whatwg",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.1.8"
+        "@juit/pgproxy-client": "1.1.9"
       }
     },
     "workspaces/persister": {
       "name": "@juit/pgproxy-persister",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.1.8",
-        "@juit/pgproxy-types": "1.1.8"
+        "@juit/pgproxy-client": "1.1.9",
+        "@juit/pgproxy-types": "1.1.9"
       }
     },
     "workspaces/pool": {
       "name": "@juit/pgproxy-pool",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "libpq": "^1.8.13"
@@ -4440,10 +4453,10 @@
     },
     "workspaces/server": {
       "name": "@juit/pgproxy-server",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-pool": "1.1.8",
+        "@juit/pgproxy-pool": "1.1.9",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -4452,7 +4465,7 @@
     },
     "workspaces/types": {
       "name": "@juit/pgproxy-types",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "postgres-date": "^2.1.0",
@@ -4462,13 +4475,13 @@
     },
     "workspaces/utils": {
       "name": "@juit/pgproxy-utils",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.1.8",
-        "@juit/pgproxy-persister": "1.1.8",
-        "@juit/pgproxy-types": "1.1.8",
-        "@plugjs/plug": "^0.6.21"
+        "@juit/pgproxy-client": "1.1.9",
+        "@juit/pgproxy-persister": "1.1.9",
+        "@juit/pgproxy-types": "1.1.9",
+        "@plugjs/plug": "^0.6.22"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-monorepo",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": "true",
   "workspaces": [
     "workspaces/pool",
@@ -41,8 +41,8 @@
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241106.0",
-    "@plugjs/build": "^0.6.14",
-    "@plugjs/tsd": "^0.6.21",
+    "@plugjs/build": "^0.6.15",
+    "@plugjs/tsd": "^0.6.22",
     "@types/ini": "^4.1.1",
     "@types/libpq": "^1.8.13",
     "@types/node": "<20",

--- a/workspaces/cli/package.json
+++ b/workspaces/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-cli",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "bin": {
     "pgproxy-server": "dist/cli.mjs"
   },
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-server": "1.1.8",
+    "@juit/pgproxy-server": "1.1.9",
     "dotenv": "^16.4.5",
     "ini": "^5.0.0",
-    "justus": "^0.5.54",
+    "justus": "^0.5.55",
     "yargs-parser": "^21.1.1"
   },
   "directories": {

--- a/workspaces/client-node/package.json
+++ b/workspaces/client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client-node",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-client": "1.1.8",
+    "@juit/pgproxy-client": "1.1.9",
     "undici": "^6.20.1"
   },
   "directories": {

--- a/workspaces/client-psql/package.json
+++ b/workspaces/client-psql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client-psql",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,8 +35,8 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-client": "1.1.8",
-    "@juit/pgproxy-pool": "1.1.8"
+    "@juit/pgproxy-client": "1.1.9",
+    "@juit/pgproxy-pool": "1.1.9"
   },
   "directories": {
     "test": "test"

--- a/workspaces/client-whatwg/package.json
+++ b/workspaces/client-whatwg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client-whatwg",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-client": "1.1.8"
+    "@juit/pgproxy-client": "1.1.9"
   },
   "directories": {
     "test": "test"

--- a/workspaces/client/package.json
+++ b/workspaces/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-types": "1.1.8"
+    "@juit/pgproxy-types": "1.1.9"
   },
   "directories": {
     "test": "test"

--- a/workspaces/persister/package.json
+++ b/workspaces/persister/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-persister",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -53,7 +53,7 @@
     "src/"
   ],
   "dependencies": {
-    "@juit/pgproxy-client": "1.1.8",
-    "@juit/pgproxy-types": "1.1.8"
+    "@juit/pgproxy-client": "1.1.9",
+    "@juit/pgproxy-types": "1.1.9"
   }
 }

--- a/workspaces/pool/package.json
+++ b/workspaces/pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-pool",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/workspaces/pool/src/events.ts
+++ b/workspaces/pool/src/events.ts
@@ -25,6 +25,11 @@ export class Emitter<E = Events> {
     }
   }
 
+  setMaxListeners(n: number): this {
+    this._emitter.setMaxListeners(n)
+    return this
+  }
+
   on<K extends keyof E>(event: K & string, callback: EventCallback<E, K>): this {
     this._emitter.on(event, callback)
     return this

--- a/workspaces/pool/src/pool.ts
+++ b/workspaces/pool/src/pool.ts
@@ -248,9 +248,16 @@ export class ConnectionPool extends Emitter<ConnectionPoolEvents> {
     assert(this._maximumIdleConnections <= this._maximumPoolSize,
         `The maximum number of idle connections ${this._maximumIdleConnections} must less or equal to the maximum pool size ${this._maximumPoolSize}`)
 
+    this.setMaxListeners(10) // default 10 listeners (plus the maximum pool size)
     this._connectionOptions = convertOptions(connectionOptions)
     this._logger = logger
   }
+
+  /** Set the maximum number of listeners for this {@link ConnectionPool}. */
+  setMaxListeners(n: number): this {
+    return super.setMaxListeners(this._maximumPoolSize + n)
+  }
+
 
   /** Statistical informations about a {@link ConnectionPool} */
   get stats(): ConnectionPoolStats {

--- a/workspaces/server/package.json
+++ b/workspaces/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-server",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-pool": "1.1.8",
+    "@juit/pgproxy-pool": "1.1.9",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/workspaces/server/test/01-token.test.ts
+++ b/workspaces/server/test/01-token.test.ts
@@ -4,15 +4,15 @@ import { createToken } from '../../../support/utils'
 import { verifyToken } from '../src/token'
 
 describe('Token verification', () => {
-  it('should not accept a token with the wrong length', () => {
+  fit('should not accept a token with the wrong length', () => {
     expect(() => verifyToken(''.padStart(63, 'A'), 'secret'))
-        .toThrowError(AssertionError, 'Invalid encoded token length (63 != 64)')
+        .toThrowError(AssertionError, /^Invalid encoded token length \(63 != 64\)/)
 
     expect(() => verifyToken(''.padStart(65, 'A'), 'secret'))
-        .toThrowError(AssertionError, 'Invalid encoded token length (65 != 64)')
+        .toThrowError(AssertionError, /^Invalid encoded token length \(65 != 64\)/)
 
     expect(() => verifyToken(''.padStart(63, 'A') + '=', 'secret'))
-        .toThrowError(AssertionError, 'Invalid decoded token length (47 != 48)')
+        .toThrowError(AssertionError, /^Invalid decoded token length \(47 != 48\)/)
   })
 
   it('should not accept a token with the wrong timestamp', () => {

--- a/workspaces/server/test/01-token.test.ts
+++ b/workspaces/server/test/01-token.test.ts
@@ -4,7 +4,7 @@ import { createToken } from '../../../support/utils'
 import { verifyToken } from '../src/token'
 
 describe('Token verification', () => {
-  fit('should not accept a token with the wrong length', () => {
+  it('should not accept a token with the wrong length', () => {
     expect(() => verifyToken(''.padStart(63, 'A'), 'secret'))
         .toThrowError(AssertionError, /^Invalid encoded token length \(63 != 64\)/)
 

--- a/workspaces/server/test/11-websocket.test.ts
+++ b/workspaces/server/test/11-websocket.test.ts
@@ -77,7 +77,7 @@ describe('Websocket Test', () => {
     }
 
     // let the pool catch up and ensure the connection was released
-    await sleep(10)
+    await sleep(100)
     expect(server.stats).toEqual({
       available: 0,
       borrowed: 0,
@@ -122,7 +122,7 @@ describe('Websocket Test', () => {
     }
 
     // let the pool catch up and ensure the connection was released
-    await sleep(10)
+    await sleep(100)
     expect(server.stats).toEqual({
       available: 0,
       borrowed: 0,
@@ -202,7 +202,7 @@ describe('Websocket Test', () => {
     }
 
     // let the pool catch up and ensure the connection was released
-    await sleep(10)
+    await sleep(100)
     expect(server.stats).toEqual({
       available: 0,
       borrowed: 0,

--- a/workspaces/types/package.json
+++ b/workspaces/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-types",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/workspaces/utils/package.json
+++ b/workspaces/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-utils",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -43,9 +43,9 @@
     "src/"
   ],
   "dependencies": {
-    "@juit/pgproxy-client": "1.1.8",
-    "@juit/pgproxy-persister": "1.1.8",
-    "@juit/pgproxy-types": "1.1.8",
-    "@plugjs/plug": "^0.6.21"
+    "@juit/pgproxy-client": "1.1.9",
+    "@juit/pgproxy-persister": "1.1.9",
+    "@juit/pgproxy-types": "1.1.9",
+    "@plugjs/plug": "^0.6.22"
   }
 }


### PR DESCRIPTION
Fixing a non-critical issue whereas with a large-ish number of connections (each one is a listener to the pool itself) the `EventEmitter` complains about too many event listeners registered.