### PR TITLE
Search typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juit/pgproxy-monorepo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juit/pgproxy-monorepo",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "workspaces": [
         "workspaces/pool",
@@ -18,18 +18,19 @@
         "workspaces/client-psql",
         "workspaces/client-whatwg",
         "workspaces/utils",
+        "workspaces/model",
         "workspaces/persister"
       ],
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20251120.0",
+        "@cloudflare/workers-types": "^4.20251121.0",
         "@plugjs/build": "^0.6.70",
-        "@plugjs/tsd": "^0.6.78",
+        "@plugjs/tsd": "^0.6.79",
         "@types/ini": "^4.1.1",
         "@types/node": "<20",
         "@types/yargs-parser": "^21.0.3",
         "libpq": "^1.8.15",
         "typescript": "^5.9.3",
-        "workerd": "^1.20251120.0"
+        "workerd": "^1.20251121.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -98,9 +99,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20251120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251120.0.tgz",
-      "integrity": "sha512-zmeyeMCX26gXAa/fTO4tOw8SZwQCluo/TRsNWXhV7o9CWTT33ooZHo0mmzbZCyZTfSRkBBUY4a0X0GzyzcNPeg==",
+      "version": "1.20251121.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251121.0.tgz",
+      "integrity": "sha512-2fwNjjwgdSpn1hRY+RV0CuaeNiSErVHVP3cdfK5QhrJ6IkRmkQ1CFgSk9VnfRKdOlMQIJcrRZ1fF2LiQxvHX+w==",
       "cpu": [
         "x64"
       ],
@@ -115,9 +116,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20251120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251120.0.tgz",
-      "integrity": "sha512-NkZsbi8LEvmfxy+QAusM5IHEAIs10CEDFzGfjgyDpPgsiPhu8ZuqePzfMWzLCMySAqJw3CGZ/7yXVOnn8UhaIg==",
+      "version": "1.20251121.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251121.0.tgz",
+      "integrity": "sha512-tulq4SL41N8pr5ApM9kpzD3BTqd/TeJyTO1ysRpKKbDBRYStF/SLMqVisP+LKKPHL3zs/HffEij+tGdfyZuyJQ==",
       "cpu": [
         "arm64"
       ],
@@ -132,9 +133,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20251120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251120.0.tgz",
-      "integrity": "sha512-RvHA9q2ouA9YKSLshbyxufY/9EF5NYDAJtYMEFVn1XJZN5sXZqIHsGm6a7wGjrQIkjzbSIyf15ZEvGZoAVocog==",
+      "version": "1.20251121.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251121.0.tgz",
+      "integrity": "sha512-u0iPZboX4qRTEDYH6pwhHTU3rW78YhnjcbLXwvegxH6nD0ZMPMAuBgTxapjau5FPG8RT3Os3UNBcu+yJlLpapQ==",
       "cpu": [
         "x64"
       ],
@@ -149,9 +150,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20251120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251120.0.tgz",
-      "integrity": "sha512-G4lNVdO0Zh2ep0ATxIR4+ZFW0Q5ILDsBKaL0o9qy6mvVpxgYv3RRLdNZ8tEm6PQ4RhE/v9vfGNtWqqjfo0J7Ew==",
+      "version": "1.20251121.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251121.0.tgz",
+      "integrity": "sha512-DF1EHyVMDhZrjoMcMGSx1qJYTO2K9pCQ9wtEeDTTjudXa7p3/r6D4l5WY1RTdRggAMHiNyxWWD6TxtdXYwSWpg==",
       "cpu": [
         "arm64"
       ],
@@ -166,9 +167,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20251120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251120.0.tgz",
-      "integrity": "sha512-Vt1QmpXyTLmOplqK9YTyTOS5S29JPYuYKG1gx2+yvA3a/udmqHk3AgGH20SbBsCN4J67usfX0DK6N163ROYIwA==",
+      "version": "1.20251121.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251121.0.tgz",
+      "integrity": "sha512-RLEP45rZLPQPsk38saBkSFuh+DacVl0lr5ZaJiriwGLuMAqrJTXmI/CkOBagemT5ydxJlmbhC0CtNLKx6qlvgA==",
       "cpu": [
         "x64"
       ],
@@ -183,9 +184,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20251120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251120.0.tgz",
-      "integrity": "sha512-/uy0Oleot60ZS037I2mxR9NEft6eQYdknKBnM76W91I+7BKznzXKj2MtXMfSXTLsxyP+6MluYRNPrRCQDlk8kw==",
+      "version": "4.20251121.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251121.0.tgz",
+      "integrity": "sha512-jzFg7hEGKzpEalxTCanN6lM8IdkvO/brsERp/+OyMms4Zi0nhDPUAg9dUcKU8wDuDUnzbjkplY6YRwle7Cq6gA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1065,6 +1066,10 @@
       "resolved": "workspaces/client-whatwg",
       "link": true
     },
+    "node_modules/@juit/pgproxy-model": {
+      "resolved": "workspaces/model",
+      "link": true
+    },
     "node_modules/@juit/pgproxy-persister": {
       "resolved": "workspaces/persister",
       "link": true
@@ -1155,24 +1160,24 @@
       }
     },
     "node_modules/@plugjs/cov8": {
-      "version": "0.6.78",
-      "resolved": "https://registry.npmjs.org/@plugjs/cov8/-/cov8-0.6.78.tgz",
-      "integrity": "sha512-a53diiWMK8eFeNt2WHAuBxQgiSwv6chCVTXKlqJnNYHbxGjGDuMKbo5IoozX5sMkFNxReUyhglrXTsA5TVOu5A==",
+      "version": "0.6.79",
+      "resolved": "https://registry.npmjs.org/@plugjs/cov8/-/cov8-0.6.79.tgz",
+      "integrity": "sha512-w7E1i6ZiyCZ5E2CWoX8GPu52f+L7P5rb3nJeoQmG2Yq9GYSdl0Jb9GsbDTJDLFJ8RKPui9JlvPqfarVSH53oWg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
-        "@plugjs/cov8-html": "^0.1.144",
-        "@plugjs/tsrun": "^0.6.24",
+        "@plugjs/cov8-html": "^0.1.145",
+        "@plugjs/tsrun": "^0.6.25",
         "source-map": "^0.7.6"
       },
       "bin": {
         "cov8": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.78"
+        "@plugjs/plug": "0.6.79"
       }
     },
     "node_modules/@plugjs/cov8-html": {
@@ -1183,9 +1188,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@plugjs/eslint": {
-      "version": "0.6.78",
-      "resolved": "https://registry.npmjs.org/@plugjs/eslint/-/eslint-0.6.78.tgz",
-      "integrity": "sha512-32W/4XNv+LpirAsb3PXMJ5f1D7+zQF5lYk9IDzhShpB+zz9woK5SIep/gKRnsBtU1kiqUkVp2ViopzJT05ABSg==",
+      "version": "0.6.79",
+      "resolved": "https://registry.npmjs.org/@plugjs/eslint/-/eslint-0.6.79.tgz",
+      "integrity": "sha512-zajpop19Fogsk6yA4FaIBtjJN5hC2oGHCirBgCAJDfADyzRGZQiLTQsUWn0fBucGxsoE5mRQ6xdhrQlbHWWIXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1193,7 +1198,7 @@
         "eslint": "^9.39.1"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.78"
+        "@plugjs/plug": "0.6.79"
       }
     },
     "node_modules/@plugjs/eslint-plugin": {
@@ -1221,30 +1226,30 @@
       }
     },
     "node_modules/@plugjs/expect5": {
-      "version": "0.6.78",
-      "resolved": "https://registry.npmjs.org/@plugjs/expect5/-/expect5-0.6.78.tgz",
-      "integrity": "sha512-l8SJabeMjRURL2OzK2A5xMSuUnn2AguCr2bz38ZkrvSajwqGNsyH1SOhx8dlYkWCqduJjv5Utp5dPMJ4ChW8+A==",
+      "version": "0.6.79",
+      "resolved": "https://registry.npmjs.org/@plugjs/expect5/-/expect5-0.6.79.tgz",
+      "integrity": "sha512-d5M4NYZr2hKQSh/QNRYEJwD9HbN6Q4A2hmR4bqWu32TdwiNGMZJrY7Ch0LvnVXke+OS9Mm4ae0llV65suQCpwA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@plugjs/tsrun": "^0.6.24"
+        "@plugjs/tsrun": "^0.6.25"
       },
       "bin": {
         "expect5": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.78"
+        "@plugjs/plug": "0.6.79"
       }
     },
     "node_modules/@plugjs/plug": {
-      "version": "0.6.78",
-      "resolved": "https://registry.npmjs.org/@plugjs/plug/-/plug-0.6.78.tgz",
-      "integrity": "sha512-7GzrTYYMeCEd6sbZjXOKourbXUkhN41TPqN0J4brXmKUCQu9ARHlwAyyMu/AsND6LtEl72XRQvgYmvcjLFUsgw==",
+      "version": "0.6.79",
+      "resolved": "https://registry.npmjs.org/@plugjs/plug/-/plug-0.6.79.tgz",
+      "integrity": "sha512-wWbcpyWZijL14pKb0Jn91K/6/8211i/fa+dgTS8w2pDs6qcqECbO8l60EldbnSjtgtb54S+QeRuqLCw/QwIb4A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@plugjs/tsrun": "^0.6.24",
+        "@plugjs/tsrun": "^0.6.25",
         "@types/node": "<21",
         "esbuild": "^0.27.0",
         "jsonc-parser": "^3.3.1",
@@ -1255,16 +1260,16 @@
       }
     },
     "node_modules/@plugjs/tsd": {
-      "version": "0.6.78",
-      "resolved": "https://registry.npmjs.org/@plugjs/tsd/-/tsd-0.6.78.tgz",
-      "integrity": "sha512-+5M7UIKZHBZrzTCHpdVdgUTaIinrJnXFa0vcihp2W9ShX1LYbh096k+rtFk64oinFju1MD+0oJrb5dIi4ukvcw==",
+      "version": "0.6.79",
+      "resolved": "https://registry.npmjs.org/@plugjs/tsd/-/tsd-0.6.79.tgz",
+      "integrity": "sha512-fUQax7FTlt3KzPpGzNWBSa0Bz4yKimVv3zM3ryJBrmNafnYs/xtDloxqF77OLp4FcipAM5l0BB+HgMImP/4tJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tsd": "^0.33.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.78"
+        "@plugjs/plug": "0.6.79"
       }
     },
     "node_modules/@plugjs/tsrun": {
@@ -1283,9 +1288,9 @@
       }
     },
     "node_modules/@plugjs/typescript": {
-      "version": "0.6.78",
-      "resolved": "https://registry.npmjs.org/@plugjs/typescript/-/typescript-0.6.78.tgz",
-      "integrity": "sha512-GeuBpojgjuzdENDWdO7+KZNpeQUMFZ0PNM7e++s+07BaItamZ9SLL4QxzbkJGG2ItMd9v5tQIl9NaUR3iywGyQ==",
+      "version": "0.6.79",
+      "resolved": "https://registry.npmjs.org/@plugjs/typescript/-/typescript-0.6.79.tgz",
+      "integrity": "sha512-lZyUDv/flMwlJ0+16+6OhPsWKRIUMUpAIVNOcD9kqolUj2vbGHVL7RrgC7kWtrUVfo+WbfBTf15sJnS623OX1w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1293,7 +1298,7 @@
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.6.78"
+        "@plugjs/plug": "0.6.79"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4798,9 +4803,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20251120.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251120.0.tgz",
-      "integrity": "sha512-7DhMqLopLaYIvulVnaMmqFxlbxP2cnWUZHnqAypsQG2tkyCPu3d/fX5AL+d+gpca/OdnW53UKJu/DG0mJnb/2g==",
+      "version": "1.20251121.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251121.0.tgz",
+      "integrity": "sha512-9hUnaDJaEKgs2K9mgU2uy7FUymdpWJoWcBsMjTu/9xRH25XQ8qDwd3DhZhdHhkiGFxEkYUip/rEU6fyBcRmXrA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4811,11 +4816,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20251120.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20251120.0",
-        "@cloudflare/workerd-linux-64": "1.20251120.0",
-        "@cloudflare/workerd-linux-arm64": "1.20251120.0",
-        "@cloudflare/workerd-windows-64": "1.20251120.0"
+        "@cloudflare/workerd-darwin-64": "1.20251121.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20251121.0",
+        "@cloudflare/workerd-linux-64": "1.20251121.0",
+        "@cloudflare/workerd-linux-arm64": "1.20251121.0",
+        "@cloudflare/workerd-windows-64": "1.20251121.0"
       }
     },
     "node_modules/ws": {
@@ -4870,10 +4875,10 @@
     },
     "workspaces/cli": {
       "name": "@juit/pgproxy-cli",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-server": "1.4.1",
+        "@juit/pgproxy-server": "1.4.2",
         "dotenv": "^17.2.3",
         "ini": "^6.0.0",
         "justus": "^0.5.104",
@@ -4885,50 +4890,55 @@
     },
     "workspaces/client": {
       "name": "@juit/pgproxy-client",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-types": "1.4.1"
+        "@juit/pgproxy-types": "1.4.2"
       }
     },
     "workspaces/client-node": {
       "name": "@juit/pgproxy-client-node",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.4.1",
+        "@juit/pgproxy-client": "1.4.2",
         "undici": "^7.16.0"
       }
     },
     "workspaces/client-psql": {
       "name": "@juit/pgproxy-client-psql",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.4.1",
-        "@juit/pgproxy-pool": "1.4.1"
+        "@juit/pgproxy-client": "1.4.2",
+        "@juit/pgproxy-pool": "1.4.2"
       }
     },
     "workspaces/client-whatwg": {
       "name": "@juit/pgproxy-client-whatwg",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.4.1"
+        "@juit/pgproxy-client": "1.4.2"
       }
+    },
+    "workspaces/model": {
+      "name": "@juit/pgproxy-model",
+      "version": "1.4.1",
+      "license": "Apache-2.0"
     },
     "workspaces/persister": {
       "name": "@juit/pgproxy-persister",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.4.1",
-        "@juit/pgproxy-types": "1.4.1"
+        "@juit/pgproxy-client": "1.4.2",
+        "@juit/pgproxy-types": "1.4.2"
       }
     },
     "workspaces/pool": {
       "name": "@juit/pgproxy-pool",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@juit/libpq": "^1.0.1"
@@ -4936,10 +4946,10 @@
     },
     "workspaces/server": {
       "name": "@juit/pgproxy-server",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-pool": "1.4.1",
+        "@juit/pgproxy-pool": "1.4.2",
         "ws": "^8.18.3"
       },
       "devDependencies": {
@@ -4948,7 +4958,7 @@
     },
     "workspaces/types": {
       "name": "@juit/pgproxy-types",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "postgres-date": "^2.1.0",
@@ -4958,12 +4968,12 @@
     },
     "workspaces/utils": {
       "name": "@juit/pgproxy-utils",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@juit/pgproxy-client": "1.4.1",
-        "@juit/pgproxy-types": "1.4.1",
-        "@plugjs/plug": "^0.6.78"
+        "@juit/pgproxy-client": "1.4.2",
+        "@juit/pgproxy-types": "1.4.2",
+        "@plugjs/plug": "^0.6.79"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3461,9 +3461,9 @@
       "license": "MIT"
     },
     "node_modules/justus": {
-      "version": "0.5.104",
-      "resolved": "https://registry.npmjs.org/justus/-/justus-0.5.104.tgz",
-      "integrity": "sha512-OtpUG0OBebtqVE/YkXOeimMA2AdI4MkUA6YnvgydrMliIglmeHaE2k+YamY7O9wX7KMkfwA+rwTKqoF/upDOog==",
+      "version": "0.5.105",
+      "resolved": "https://registry.npmjs.org/justus/-/justus-0.5.105.tgz",
+      "integrity": "sha512-/lC/X0S2FUd1dUWccYYWPZZ1TqUR4dtzYCI4aV/lh/DElbK4T+bV6UVuWzw1U0AFNcEGdmc6DEK4x7NpOXloig==",
       "license": "Apache-2.0"
     },
     "node_modules/keyv": {
@@ -4881,7 +4881,7 @@
         "@juit/pgproxy-server": "1.4.2",
         "dotenv": "^17.2.3",
         "ini": "^6.0.0",
-        "justus": "^0.5.104",
+        "justus": "^0.5.105",
         "yargs-parser": "^22.0.0"
       },
       "bin": {
@@ -4924,7 +4924,7 @@
     },
     "workspaces/model": {
       "name": "@juit/pgproxy-model",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0"
     },
     "workspaces/persister": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4933,6 +4933,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@juit/pgproxy-client": "1.4.2",
+        "@juit/pgproxy-model": "1.4.2",
         "@juit/pgproxy-types": "1.4.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-monorepo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": "true",
   "workspaces": [
     "workspaces/pool",
@@ -12,6 +12,7 @@
     "workspaces/client-psql",
     "workspaces/client-whatwg",
     "workspaces/utils",
+    "workspaces/model",
     "workspaces/persister"
   ],
   "scripts": {
@@ -40,15 +41,15 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20251120.0",
+    "@cloudflare/workers-types": "^4.20251121.0",
     "@plugjs/build": "^0.6.70",
-    "@plugjs/tsd": "^0.6.78",
+    "@plugjs/tsd": "^0.6.79",
     "@types/ini": "^4.1.1",
     "@types/node": "<20",
     "@types/yargs-parser": "^21.0.3",
     "libpq": "^1.8.15",
     "typescript": "^5.9.3",
-    "workerd": "^1.20251120.0"
+    "workerd": "^1.20251121.0"
   },
   "files": [
     "*.md",

--- a/test-d/02-search.test-d.ts
+++ b/test-d/02-search.test-d.ts
@@ -1,0 +1,171 @@
+import { expectType, printType } from 'tsd'
+
+import type { SearchOptions, SearchResult } from '../workspaces/model/src/index'
+
+printType('__file_marker__')
+
+interface TestSchema {
+  'joined': {
+    'uuid': {
+      type: string
+      hasDefault: true
+    }
+    'key': {
+      type: string
+    }
+    'date': {
+      type: Date
+      isNullable: true
+    }
+    'json': {
+      type: any
+      isNullable: true
+    }
+  }
+  'main': {
+    'uuid': {
+      type: string
+      hasDefault: true
+    }
+    'ref': {
+      type: string
+      isNullable: true
+    }
+    'key': {
+      type: string
+    }
+    'date': {
+      type: Date
+    }
+    'number': {
+      type: number
+      isNullable: true
+    }
+    'json': {
+      type: any
+      isNullable: true
+    }
+  }
+}
+
+type TestJoins = {
+  referenced: { column: 'ref', refTable: 'joined', refColumn: 'uuid', sortColumn: 'key' },
+}
+
+type TestJoins2 = {
+  referenced: { column: 'key', refTable: 'joined', refColumn: 'key' },
+}
+
+/* ===== SEARCH OPTIONS ===================================================== */
+
+// With joins
+expectType<{
+  limit?: number | undefined,
+  offset?: number | undefined,
+  sort?: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json' // from the main table
+       | 'referenced' // joined table sort column
+       | undefined,
+  order?: 'asc' | 'desc' | undefined,
+  q?: string | undefined,
+  filters?: ({
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: string | undefined,
+    op?: '=' | '!=' | '>' | '>=' | '<' | '<=' | '~' | 'like' | 'ilike'
+    value: string | number | Date | boolean | null
+  } | {
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: string | undefined,
+    op: 'in' | 'not in',
+    value: (string | number | Date | boolean | null)[]
+  } | {
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: never,
+    op: '@>' | '<@',
+    value: any
+  })[] | undefined
+}>(null as any as SearchOptions<TestSchema, 'main', TestJoins>)
+
+// With non-sortable joins
+expectType<{
+  limit?: number | undefined,
+  offset?: number | undefined,
+  sort?: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json' // from the main table
+       | undefined, // no 'referenced' here... it's not sortable!
+  order?: 'asc' | 'desc' | undefined,
+  q?: string | undefined,
+  filters?: ({
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: string | undefined,
+    op?: '=' | '!=' | '>' | '>=' | '<' | '<=' | '~' | 'like' | 'ilike'
+    value: string | number | Date | boolean | null
+  } | {
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: string | undefined,
+    op: 'in' | 'not in',
+    value: (string | number | Date | boolean | null)[]
+  } | {
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: never,
+    op: '@>' | '<@',
+    value: any
+  })[] | undefined
+}>(null as any as SearchOptions<TestSchema, 'main', TestJoins2>)
+
+// With joins
+expectType<{
+  limit?: number | undefined,
+  offset?: number | undefined,
+  sort?: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json' | undefined,
+  order?: 'asc' | 'desc' | undefined,
+  q?: string | undefined,
+  filters?: ({
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: string | undefined,
+    op?: '=' | '!=' | '>' | '>=' | '<' | '<=' | '~' | 'like' | 'ilike'
+    value: string | number | Date | boolean | null
+  } | {
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: string | undefined,
+    op: 'in' | 'not in',
+    value: (string | number | Date | boolean | null)[]
+  } | {
+    name: 'uuid' | 'ref' | 'key' | 'date' | 'number' | 'json',
+    field?: never,
+    op: '@>' | '<@',
+    value: any
+  })[] | undefined
+}>(null as any as SearchOptions<TestSchema, 'main', {}>)
+
+/* ===== SEARCH RESULTS ===================================================== */
+
+// With nullable joins
+expectType<{
+  uuid: string;
+  ref: string | null;
+  key: string;
+  date: Date;
+  number: number | null;
+  json: any | null;
+  referenced: null | {
+    uuid: string;
+    key: string;
+    date: Date | null;
+    json: any | null;
+  }
+}>(null as any as SearchResult<TestSchema, 'main', TestJoins>)
+
+// With non-nullable joins
+expectType<{
+  uuid: string;
+  ref: string | null;
+  key: string;
+  date: Date;
+  number: number | null;
+  json: any | null;
+  referenced: {
+    uuid: string;
+    key: string;
+    date: Date | null;
+    json: any | null;
+  }
+}>(null as any as SearchResult<TestSchema, 'main', TestJoins2>)

--- a/tsconfig-transpile.json
+++ b/tsconfig-transpile.json
@@ -15,5 +15,6 @@
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "verbatimModuleSyntax": true,
+    "noErrorTruncation": true,
   },
 }

--- a/tsconfig-transpile.json
+++ b/tsconfig-transpile.json
@@ -10,11 +10,11 @@
     "noEmit": true,
 
     "strict": true,
+    "noErrorTruncation": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "verbatimModuleSyntax": true,
-    "noErrorTruncation": true,
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "@juit/pgproxy-client-node": [ "./workspaces/client-node/src/index.ts" ],
       "@juit/pgproxy-client-psql": [ "./workspaces/client-psql/src/index.ts" ],
       "@juit/pgproxy-client-whatwg": [ "./workspaces/client-whatwg/src/index.ts" ],
+      "@juit/pgproxy-model": [ "./workspaces/model/src/index.ts" ],
       "@juit/pgproxy-persister": [ "./workspaces/persister/src/index.ts" ],
       "@juit/pgproxy-pool": [ "./workspaces/pool/src/index.ts" ],
       "@juit/pgproxy-server": [ "./workspaces/server/src/index.ts" ],

--- a/workspaces/cli/package.json
+++ b/workspaces/cli/package.json
@@ -26,7 +26,7 @@
     "@juit/pgproxy-server": "1.4.2",
     "dotenv": "^17.2.3",
     "ini": "^6.0.0",
-    "justus": "^0.5.104",
+    "justus": "^0.5.105",
     "yargs-parser": "^22.0.0"
   },
   "directories": {

--- a/workspaces/cli/package.json
+++ b/workspaces/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-cli",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "bin": {
     "pgproxy-server": "dist/cli.mjs"
   },
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-server": "1.4.1",
+    "@juit/pgproxy-server": "1.4.2",
     "dotenv": "^17.2.3",
     "ini": "^6.0.0",
     "justus": "^0.5.104",

--- a/workspaces/client-node/package.json
+++ b/workspaces/client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client-node",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-client": "1.4.1",
+    "@juit/pgproxy-client": "1.4.2",
     "undici": "^7.16.0"
   },
   "directories": {

--- a/workspaces/client-psql/package.json
+++ b/workspaces/client-psql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client-psql",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,8 +35,8 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-client": "1.4.1",
-    "@juit/pgproxy-pool": "1.4.1"
+    "@juit/pgproxy-client": "1.4.2",
+    "@juit/pgproxy-pool": "1.4.2"
   },
   "directories": {
     "test": "test"

--- a/workspaces/client-whatwg/package.json
+++ b/workspaces/client-whatwg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client-whatwg",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-client": "1.4.1"
+    "@juit/pgproxy-client": "1.4.2"
   },
   "directories": {
     "test": "test"

--- a/workspaces/client/package.json
+++ b/workspaces/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-client",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-types": "1.4.1"
+    "@juit/pgproxy-types": "1.4.2"
   },
   "directories": {
     "test": "test"

--- a/workspaces/model/README.md
+++ b/workspaces/model/README.md
@@ -1,0 +1,12 @@
+# PostgreSQL Proxy Persister Model Types
+
+This package exports _only the types_ required by the [PGProxy Persister
+interface](https://github.com/juitnow/juit-pgproxy/blob/main/workspaces/persister/README.md).
+
+This simplifies type management allowing **consumers** of libraries and APIs
+using Persister to ship this (and their inferred types) as a simple dependency
+without bringing in any extra code.
+
+* [PGProxy](https://github.com/juitnow/juit-pgproxy/blob/main/README.md)
+* [Copyright Notice](https://github.com/juitnow/juit-pgproxy/blob/main/NOTICE.md)
+* [License](https://github.com/juitnow/juit-pgproxy/blob/main/NOTICE.md)

--- a/workspaces/model/package.json
+++ b/workspaces/model/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@juit/pgproxy-model",
+  "version": "1.4.1",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "scripts": {},
+  "author": "Juit Developers <developers@juit.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/juitnow/juit-pgproxy.git"
+  },
+  "keywords": [
+    "database",
+    "pg",
+    "pool",
+    "postgres",
+    "proxy"
+  ],
+  "bugs": {
+    "url": "https://github.com/juitnow/juit-pgproxy/issues"
+  },
+  "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
+  "directories": {
+    "test": "test"
+  },
+  "files": [
+    "*.md",
+    "dist/",
+    "src/"
+  ]
+}

--- a/workspaces/model/package.json
+++ b/workspaces/model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-model",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/workspaces/model/src/index.ts
+++ b/workspaces/model/src/index.ts
@@ -1,0 +1,2 @@
+export type * from './model'
+export type * from './search'

--- a/workspaces/model/src/model.ts
+++ b/workspaces/model/src/model.ts
@@ -17,63 +17,60 @@ export interface ColumnDefinition<T = any> {
 }
 
 /** Infer the TypeScript type suitable for an `INSERT` in a table */
-export type InferInsertType<Table extends Record<string, ColumnDefinition>> =
-  Prettify<{
-    /* First part: all nullable or defaulted columns are optional */
-    [ Column in keyof Table as Column extends string
-      ? Table[Column]['isGenerated'] extends true ? never
-      : Table[Column]['isNullable'] extends true ? Column
-      : Table[Column]['hasDefault'] extends true ? Column
-      : never
-      : never
-    ] ? :
-    Table[Column]['isNullable'] extends true
-      ? Table[Column]['type'] | null
-      : Table[Column]['type']
-  } & {
-    /* Second part: all non-nullable or non-defaulted columns are required */
-    [ Column in keyof Table as Column extends string
-      ? Table[Column]['isGenerated'] extends true ? never
-      : Table[Column]['isNullable'] extends true ? never
-      : Table[Column]['hasDefault'] extends true ? never
-      : Column
-      : never
-    ] -? :
-    Table[Column]['isNullable'] extends true
-      ? Table[Column]['type'] | null
-      : Table[Column]['type']
-  }>
+export type InferInsertType<Table extends Record<string, ColumnDefinition>> = Prettify<{
+  /* First part: all nullable or defaulted columns are optional */
+  [ Column in keyof Table as Column extends string
+    ? Table[Column]['isGenerated'] extends true ? never
+    : Table[Column]['isNullable'] extends true ? Column
+    : Table[Column]['hasDefault'] extends true ? Column
+    : never
+    : never
+  ] ? :
+  Table[Column]['isNullable'] extends true
+    ? Table[Column]['type'] | null
+    : Table[Column]['type']
+} & {
+  /* Second part: all non-nullable or non-defaulted columns are required */
+  [ Column in keyof Table as Column extends string
+    ? Table[Column]['isGenerated'] extends true ? never
+    : Table[Column]['isNullable'] extends true ? never
+    : Table[Column]['hasDefault'] extends true ? never
+    : Column
+    : never
+  ] -? :
+  Table[Column]['isNullable'] extends true
+    ? Table[Column]['type'] | null
+    : Table[Column]['type']
+}>
 
 /** Infer the TypeScript type suitable for a `SELECT` from a table */
-export type InferSelectType<Table extends Record<string, ColumnDefinition>> =
-  Prettify<{
-    [ Column in keyof Table as Column extends string ? Column : never ] -? :
-      ( Table[Column]['isNullable'] extends true ?
-        Table[Column]['type'] | null :
-        Table[Column]['type']
-      ) & ( Table[Column] extends { branding: infer Brand } ? Brand : unknown )
-  }>
+export type InferSelectType<Table extends Record<string, ColumnDefinition>> = {
+  [ Column in keyof Table as Column extends string ? Column : never ] -? :
+    ( Table[Column]['isNullable'] extends true
+      ? Table[Column]['type'] | null
+      : Table[Column]['type']
+    ) & ( Table[Column] extends { branding: infer Brand } ? Brand : unknown )
+}
 
 /** Infer the TypeScript type suitable for a `UPDATE` in a table */
-export type InferUpdateType<Table extends Record<string, ColumnDefinition>> =
-  Prettify<{
-    [ Column in keyof Table as Column extends string
-      ? Table[Column]['isGenerated'] extends true ? never
-      : Column
-      : never
-    ] ? :
-    Table[Column]['isNullable'] extends true ?
-      Table[Column]['type'] | null :
-      Table[Column]['type']
-  }>
+export type InferUpdateType<Table extends Record<string, ColumnDefinition>> = {
+  [ Column in keyof Table as Column extends string
+    ? Table[Column]['isGenerated'] extends true ? never
+    : Column
+    : never
+  ] ? :
+  Table[Column]['isNullable'] extends true
+    ? Table[Column]['type'] | null
+    : Table[Column]['type']
+}
 
 /** Infer the TypeScript type used for querying records */
-export type InferQueryType<Table extends Record<string, ColumnDefinition>> =
-  Prettify<{ [ Column in keyof Table as Column extends string ? Column : never ] ? :
-    Table[Column]['isNullable'] extends true ?
-        Table[Column]['type'] | null :
-      Table[Column]['type']
-  }>
+export type InferQueryType<Table extends Record<string, ColumnDefinition>> ={
+  [ Column in keyof Table as Column extends string ? Column : never ] ? :
+  Table[Column]['isNullable'] extends true
+    ? Table[Column]['type'] | null
+    : Table[Column]['type']
+}
 
 /** Infer the available sort values for a table (as required by `ORDER BY`) */
 export type InferSort<Table extends Record<string, ColumnDefinition>> =

--- a/workspaces/model/src/model.ts
+++ b/workspaces/model/src/model.ts
@@ -1,0 +1,80 @@
+/* ========================================================================== *
+ * TYPE INFERENCE: FROM SCHEMA->TABLE->COLUMN->... TO JS TYPES                *
+ * ========================================================================== */
+
+type SimplifyIntersection<T> = { [ K in keyof T ]: T[K] }
+type OnlyStrings<T> = T extends string ? T : never
+
+/** The definition of a column */
+export interface ColumnDefinition<T = any> {
+  /** The TypeScript type of the column (from the type parser) */
+  type: T,
+  /** Whether the column is _generated_ or not */
+  isGenerated?: boolean,
+  /** Whether the column is _nullable_ or not */
+  isNullable?: boolean,
+  /** Whether the column _specifies a default value_ or not */
+  hasDefault?: boolean,
+}
+
+/** Infer the TypeScript type suitable for an `INSERT` in a table */
+export type InferInsertType<Table extends Record<string, ColumnDefinition>> =
+  SimplifyIntersection<{
+    /* First part: all nullable or defaulted columns are optional */
+    [ Column in keyof Table as Column extends string
+      ? Table[Column]['isGenerated'] extends true ? never
+      : Table[Column]['isNullable'] extends true ? Column
+      : Table[Column]['hasDefault'] extends true ? Column
+      : never
+      : never
+    ] ? :
+    Table[Column]['isNullable'] extends true
+      ? Table[Column]['type'] | null
+      : Table[Column]['type']
+  } & {
+    /* Second part: all non-nullable or non-defaulted columns are required */
+    [ Column in keyof Table as Column extends string
+      ? Table[Column]['isGenerated'] extends true ? never
+      : Table[Column]['isNullable'] extends true ? never
+      : Table[Column]['hasDefault'] extends true ? never
+      : Column
+      : never
+    ] -? :
+    Table[Column]['isNullable'] extends true
+      ? Table[Column]['type'] | null
+      : Table[Column]['type']
+  }>
+
+/** Infer the TypeScript type suitable for a `SELECT` from a table */
+export type InferSelectType<Table extends Record<string, ColumnDefinition>> =
+  { [ Column in keyof Table as Column extends string ? Column : never ] -? :
+    ( Table[Column]['isNullable'] extends true ?
+      Table[Column]['type'] | null :
+      Table[Column]['type']
+    ) & ( Table[Column] extends { branding: infer Brand } ? Brand : unknown )
+
+  }
+
+/** Infer the TypeScript type suitable for a `UPDATE` in a table */
+export type InferUpdateType<Table extends Record<string, ColumnDefinition>> ={
+  [ Column in keyof Table as Column extends string
+    ? Table[Column]['isGenerated'] extends true ? never
+    : Column
+    : never
+  ] ? :
+  Table[Column]['isNullable'] extends true ?
+    Table[Column]['type'] | null :
+    Table[Column]['type']
+}
+
+/** Infer the TypeScript type used for querying records */
+export type InferQueryType<Table extends Record<string, ColumnDefinition>> =
+  { [ Column in keyof Table as Column extends string ? Column : never ] ? :
+    Table[Column]['isNullable'] extends true ?
+        Table[Column]['type'] | null :
+      Table[Column]['type']
+  }
+
+/** Infer the available sort values for a table (as required by `ORDER BY`) */
+export type InferSort<Table extends Record<string, ColumnDefinition>> =
+  `${OnlyStrings<keyof Table>}${' ASC' | ' asc' | ' DESC' | ' desc' | ''}`

--- a/workspaces/model/src/model.ts
+++ b/workspaces/model/src/model.ts
@@ -1,9 +1,8 @@
+import type { OnlyStrings, Prettify } from './utils'
+
 /* ========================================================================== *
  * TYPE INFERENCE: FROM SCHEMA->TABLE->COLUMN->... TO JS TYPES                *
  * ========================================================================== */
-
-type SimplifyIntersection<T> = { [ K in keyof T ]: T[K] }
-type OnlyStrings<T> = T extends string ? T : never
 
 /** The definition of a column */
 export interface ColumnDefinition<T = any> {
@@ -19,7 +18,7 @@ export interface ColumnDefinition<T = any> {
 
 /** Infer the TypeScript type suitable for an `INSERT` in a table */
 export type InferInsertType<Table extends Record<string, ColumnDefinition>> =
-  SimplifyIntersection<{
+  Prettify<{
     /* First part: all nullable or defaulted columns are optional */
     [ Column in keyof Table as Column extends string
       ? Table[Column]['isGenerated'] extends true ? never
@@ -47,33 +46,34 @@ export type InferInsertType<Table extends Record<string, ColumnDefinition>> =
 
 /** Infer the TypeScript type suitable for a `SELECT` from a table */
 export type InferSelectType<Table extends Record<string, ColumnDefinition>> =
-  { [ Column in keyof Table as Column extends string ? Column : never ] -? :
-    ( Table[Column]['isNullable'] extends true ?
-      Table[Column]['type'] | null :
-      Table[Column]['type']
-    ) & ( Table[Column] extends { branding: infer Brand } ? Brand : unknown )
-
-  }
+  Prettify<{
+    [ Column in keyof Table as Column extends string ? Column : never ] -? :
+      ( Table[Column]['isNullable'] extends true ?
+        Table[Column]['type'] | null :
+        Table[Column]['type']
+      ) & ( Table[Column] extends { branding: infer Brand } ? Brand : unknown )
+  }>
 
 /** Infer the TypeScript type suitable for a `UPDATE` in a table */
-export type InferUpdateType<Table extends Record<string, ColumnDefinition>> ={
-  [ Column in keyof Table as Column extends string
-    ? Table[Column]['isGenerated'] extends true ? never
-    : Column
-    : never
-  ] ? :
-  Table[Column]['isNullable'] extends true ?
-    Table[Column]['type'] | null :
-    Table[Column]['type']
-}
+export type InferUpdateType<Table extends Record<string, ColumnDefinition>> =
+  Prettify<{
+    [ Column in keyof Table as Column extends string
+      ? Table[Column]['isGenerated'] extends true ? never
+      : Column
+      : never
+    ] ? :
+    Table[Column]['isNullable'] extends true ?
+      Table[Column]['type'] | null :
+      Table[Column]['type']
+  }>
 
 /** Infer the TypeScript type used for querying records */
 export type InferQueryType<Table extends Record<string, ColumnDefinition>> =
-  { [ Column in keyof Table as Column extends string ? Column : never ] ? :
+  Prettify<{ [ Column in keyof Table as Column extends string ? Column : never ] ? :
     Table[Column]['isNullable'] extends true ?
         Table[Column]['type'] | null :
       Table[Column]['type']
-  }
+  }>
 
 /** Infer the available sort values for a table (as required by `ORDER BY`) */
 export type InferSort<Table extends Record<string, ColumnDefinition>> =

--- a/workspaces/model/src/search.ts
+++ b/workspaces/model/src/search.ts
@@ -1,0 +1,186 @@
+import type { ColumnDefinition, InferSelectType } from './model'
+
+/* ========================================================================== *
+ * JOINS                                                                      *
+ * ========================================================================== */
+
+/**
+ * Definition for a simple (straight) join in a {@link Search}
+ */
+export interface SearchJoin<Schema> {
+  /**
+   * The column in _the search table_ (passed to the constructor of
+   * {@link Search}) referencing the specified `refTable` (defined here).
+   *
+   * ```sql
+   * ... LEFT JOIN "refTable" ON "table"."column" = "refTable"."refColumn"
+   *                                      ^^^^^^
+   * ```
+   */
+  column: string
+  /**
+   * The name of the table to _left join_.
+   *
+   * ```sql
+   * ... LEFT JOIN "refTable" ON "table"."column" = "refTable"."refColumn"
+   *                ^^^^^^^^                         ^^^^^^^^
+   * ```
+   */
+  refTable: string & keyof Schema
+  /**
+   * The column in the `refTable` referenced by the _the search table_.
+   *
+   * ```sql
+   * ... LEFT JOIN "refTable" ON "table"."column" = "refTable"."refColumn"
+   *                                                            ^^^^^^^^^
+   * ```
+   */
+  refColumn: string
+  /**
+   * The column in the referenced table to use as default sort column, when
+   * sorting by this join.
+   */
+  sortColumn?: string
+}
+
+/**
+ * Definition for joins in a {@link Search}
+ *
+ * Each key is the name of the join as it will appear in the results, and the
+ * value defines how to perform the join.
+ *
+ * See {@link StraightJoin} and {@link LinkedJoin} for details on the fields.
+ */
+export interface SearchJoins<Schema> {
+  [ key: string ]: SearchJoin<Schema>
+}
+
+/* ========================================================================== *
+ * SEARCH OPTIONS                                                             *
+ * ========================================================================== */
+
+/** Internal interface defining operators available to *single values* */
+interface ValueSearchFilter<
+  Schema,
+  Table extends string & keyof Schema,
+> {
+  name: string & keyof Schema[Table]
+  field?: string
+  op?: '=' | '!=' | '>' | '>=' | '<' | '<=' | '~' | 'like' | 'ilike'
+  value: string | number | Date | boolean | null
+}
+
+/** Internal interface defining operators available to *array values* */
+interface ArraySearchFilter<
+  Schema,
+  Table extends string & keyof Schema,
+> {
+  name: string & keyof Schema[Table]
+  field?: string
+  op: 'in' | 'not in'
+  value: (string | number | Date | boolean | null)[]
+}
+
+/** Internal interface defining operators available to *json values* */
+interface JsonSearchFilter<
+  Schema,
+  Table extends string & keyof Schema,
+> {
+  name: string & keyof Schema[Table]
+  field?: never
+  op: '@>' | '<@'
+  value: any
+}
+
+/**
+ * A filter for a search that matches a single value
+ *
+ * - `name` is the column name to filter on
+ * - `field` is a field to filter on when the column is a complex type (JSONB)
+ * - `op` is the operator to use for the filter (default: `=`)
+ * - `value` is the value to filter for
+ *
+ * All operators are defined as per PostgreSQL documentation, with few notable
+ * exceptions:
+ *
+ * - `~` is an alias to the `ilike` operator
+ * - `in` and `not in` are used to match a value against an array of possible
+ *   values using the `... = ANY(...)`  or `... != ALL(...)` constructs
+ * - `@>` and `<@` will accept single values as well as arrays.
+ * - `!=` and `=` will use the PostgreSQL `IS (NOT) DISTINCT FROM` semantics
+ *   to properly handle `NULL` comparisons.
+ */
+export type SearchFilter<
+  Schema,
+  Table extends string & keyof Schema,
+> = ValueSearchFilter<Schema, Table> | ArraySearchFilter<Schema, Table> | JsonSearchFilter<Schema, Table>
+
+/**
+ * Base interface for querying results via our {@link Search}.
+ */
+export interface SearchQuery<
+  Schema,
+  Table extends string & keyof Schema,
+  Joins extends SearchJoins<Schema>,
+> {
+  /** An optional set of filters to apply */
+  filters?: SearchFilter<Schema, Table>[]
+  /** An optional column to sort by */
+  sort?: string & (keyof Schema[Table] | keyof Joins)
+  /** The order to sort by (if `sort` is specified, default: 'asc') */
+  order?: 'asc' | 'desc'
+  /** An optional full-text search query, available for full-text search */
+  q?: string
+}
+
+/**
+ * Full options for querying a limited set of results via our {@link Search}.
+ */
+export interface SearchOptions<
+  Schema,
+  Table extends string & keyof Schema,
+  Joins extends SearchJoins<Schema>,
+> extends SearchQuery<Schema, Table, Joins> {
+  /** Offset to start returning rows from (default: 0) */
+  offset?: number
+  /** Maximum number of rows to return (default: 20, unlimited if 0) */
+  limit?: number
+}
+
+/* ========================================================================== *
+ * SEARCH RESULTS                                                             *
+ * ========================================================================== */
+
+/** A single search result row (with joins) */
+export type SearchResult<
+  Schema,
+  Table extends string & keyof Schema,
+  Joins extends SearchJoins<Schema> = {},
+> =
+  Schema[Table] extends Record<string, ColumnDefinition> ?
+  // This is the main table's column field
+  InferSelectType<Schema[Table]> & {
+    // For each join, add a field with the joined table's inferred type
+    [ key in keyof Joins ] : Joins[key]['refTable'] extends keyof Schema ?
+      // If the column referencing this join is nullable, the result can be null
+      Schema[Joins[key]['refTable']] extends Record<string, ColumnDefinition> ?
+        Schema[Table][Joins[key]['column']]['isNullable'] extends true ?
+          InferSelectType<Schema[Joins[key]['refTable']]> | null :
+          InferSelectType<Schema[Joins[key]['refTable']]> :
+        // If the joined table isn't a column def, we can't infer anything
+        unknown :
+      // If the table doesn't exist in the schema, we can't infer anything
+      unknown
+  } : never
+
+/** What's being returned by our `search` */
+export interface SearchResults<
+  Schema,
+  Table extends string & keyof Schema,
+  Joins extends SearchJoins<Schema> = {},
+> {
+  /** The total length of all available results (without offset or limit) */
+  total: number
+  /** The lines queried (truncated by offset and limit) */
+  rows: SearchResult<Schema, Table, Joins>[]
+}

--- a/workspaces/model/src/utils.ts
+++ b/workspaces/model/src/utils.ts
@@ -1,0 +1,4 @@
+/** Prettify a type by flattening intersections */
+export type Prettify<T extends object> = { [ K in keyof T ]: T[K] } & {}
+/** Extract only the string keys from a type */
+export type OnlyStrings<T> = T extends string ? T : never

--- a/workspaces/model/test/00-exports.test.ts
+++ b/workspaces/model/test/00-exports.test.ts
@@ -1,0 +1,7 @@
+import * as models from '../src/index'
+
+describe('Persister Models', () => {
+  it('should export absolutely nothing', () => {
+    expect({ ...models }).toEqual({}) // might have a "null" prototype
+  })
+})

--- a/workspaces/model/test/tsconfig.json
+++ b/workspaces/model/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig-test.json",
+  "include": [ "." ],
+}

--- a/workspaces/model/tsconfig-transpile.json
+++ b/workspaces/model/tsconfig-transpile.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig-transpile.json",
+  "compilerOptions": {
+    "lib": [ "esnext", "webworker" ],
+  },
+  "include": [ "./src" ],
+}

--- a/workspaces/model/tsconfig.json
+++ b/workspaces/model/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": [ "esnext" ],
+  },
+  "include": [ "./src" ],
+}

--- a/workspaces/persister/package.json
+++ b/workspaces/persister/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-persister",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -13,16 +13,6 @@
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.mjs"
-      }
-    },
-    "./schema": {
-      "require": {
-        "types": "./dist/schema.d.ts",
-        "default": "./dist/schema.cjs"
-      },
-      "import": {
-        "types": "./dist/schema.d.ts",
-        "default": "./dist/schema.mjs"
       }
     }
   },
@@ -53,7 +43,7 @@
     "src/"
   ],
   "dependencies": {
-    "@juit/pgproxy-client": "1.4.1",
-    "@juit/pgproxy-types": "1.4.1"
+    "@juit/pgproxy-client": "1.4.2",
+    "@juit/pgproxy-types": "1.4.2"
   }
 }

--- a/workspaces/persister/package.json
+++ b/workspaces/persister/package.json
@@ -44,6 +44,7 @@
   ],
   "dependencies": {
     "@juit/pgproxy-client": "1.4.2",
+    "@juit/pgproxy-model": "1.4.2",
     "@juit/pgproxy-types": "1.4.2"
   }
 }

--- a/workspaces/persister/src/index.ts
+++ b/workspaces/persister/src/index.ts
@@ -3,3 +3,6 @@ export { escape, SQL } from '@juit/pgproxy-client'
 export * from './model'
 export * from './persister'
 export * from './search'
+
+/* Re-export model types */
+export type * from '@juit/pgproxy-model'

--- a/workspaces/persister/src/model.ts
+++ b/workspaces/persister/src/model.ts
@@ -355,12 +355,12 @@ class ModelImpl<Table extends Record<string, ColumnDefinition>> implements Model
   }
 
   async read(
-      query?: InferQueryType<Table>,
+      query: InferQueryType<Table> = {},
       sort: InferSort<Table> | InferSort<Table>[] = [],
       offset: number = 0,
       limit: number = 0,
   ): Promise<InferSelectType<Table>[]> {
-    const [ sql, params ] = select(this._etable, query || {}, sort, offset, limit)
+    const [ sql, params ] = select(this._etable, query, sort, offset, limit)
     const result = await this._connection.query<InferSelectType<Table>>(sql, params)
     return result.rows
   }

--- a/workspaces/persister/src/model.ts
+++ b/workspaces/persister/src/model.ts
@@ -3,87 +3,14 @@ import { escape } from '@juit/pgproxy-client'
 import { assert, assertArray, assertObject, encodeSchemaAndName } from './utils'
 
 import type { PGQueryable } from '@juit/pgproxy-client'
-
-/* ========================================================================== *
- * TYPE INFERENCE: FROM SCHEMA->TABLE->COLUMN->... TO JS TYPES                *
- * ========================================================================== */
-
-type SimplifyIntersection<T> = { [ K in keyof T ]: T[K] }
-type OnlyStrings<T> = T extends string ? T : never
-
-/** The definition of a column */
-export interface ColumnDefinition<T = any> {
-  /** The TypeScript type of the column (from the type parser) */
-  type: T,
-  /** Whether the column is _generated_ or not */
-  isGenerated?: boolean,
-  /** Whether the column is _nullable_ or not */
-  isNullable?: boolean,
-  /** Whether the column _specifies a default value_ or not */
-  hasDefault?: boolean,
-}
-
-/** Infer the TypeScript type suitable for an `INSERT` in a table */
-export type InferInsertType<Table extends Record<string, ColumnDefinition>> =
-  SimplifyIntersection<{
-    /* First part: all nullable or defaulted columns are optional */
-    [ Column in keyof Table as Column extends string
-      ? Table[Column]['isGenerated'] extends true ? never
-      : Table[Column]['isNullable'] extends true ? Column
-      : Table[Column]['hasDefault'] extends true ? Column
-      : never
-      : never
-    ] ? :
-    Table[Column]['isNullable'] extends true
-      ? Table[Column]['type'] | null
-      : Table[Column]['type']
-  } & {
-    /* Second part: all non-nullable or non-defaulted columns are required */
-    [ Column in keyof Table as Column extends string
-      ? Table[Column]['isGenerated'] extends true ? never
-      : Table[Column]['isNullable'] extends true ? never
-      : Table[Column]['hasDefault'] extends true ? never
-      : Column
-      : never
-    ] -? :
-    Table[Column]['isNullable'] extends true
-      ? Table[Column]['type'] | null
-      : Table[Column]['type']
-  }>
-
-/** Infer the TypeScript type suitable for a `SELECT` from a table */
-export type InferSelectType<Table extends Record<string, ColumnDefinition>> =
-  { [ Column in keyof Table as Column extends string ? Column : never ] -? :
-    ( Table[Column]['isNullable'] extends true ?
-      Table[Column]['type'] | null :
-      Table[Column]['type']
-    ) & ( Table[Column] extends { branding: infer Brand } ? Brand : unknown )
-
-  }
-
-/** Infer the TypeScript type suitable for a `UPDATE` in a table */
-export type InferUpdateType<Table extends Record<string, ColumnDefinition>> ={
-  [ Column in keyof Table as Column extends string
-    ? Table[Column]['isGenerated'] extends true ? never
-    : Column
-    : never
-  ] ? :
-  Table[Column]['isNullable'] extends true ?
-    Table[Column]['type'] | null :
-    Table[Column]['type']
-}
-
-/** Infer the TypeScript type used for querying records */
-export type InferQueryType<Table extends Record<string, ColumnDefinition>> =
-  { [ Column in keyof Table as Column extends string ? Column : never ] ? :
-    Table[Column]['isNullable'] extends true ?
-        Table[Column]['type'] | null :
-      Table[Column]['type']
-  }
-
-/** Infer the available sort values for a table (as required by `ORDER BY`) */
-export type InferSort<Table extends Record<string, ColumnDefinition>> =
-  `${OnlyStrings<keyof Table>}${' ASC' | ' asc' | ' DESC' | ' desc' | ''}`
+import type {
+  ColumnDefinition,
+  InferInsertType,
+  InferQueryType,
+  InferSelectType,
+  InferSort,
+  InferUpdateType,
+} from '@juit/pgproxy-model'
 
 /* ========================================================================== *
  * MODEL INTERFACE                                                            *

--- a/workspaces/persister/src/model.ts
+++ b/workspaces/persister/src/model.ts
@@ -355,12 +355,12 @@ class ModelImpl<Table extends Record<string, ColumnDefinition>> implements Model
   }
 
   async read(
-      query: InferQueryType<Table> = {},
+      query?: InferQueryType<Table>,
       sort: InferSort<Table> | InferSort<Table>[] = [],
       offset: number = 0,
       limit: number = 0,
   ): Promise<InferSelectType<Table>[]> {
-    const [ sql, params ] = select(this._etable, query, sort, offset, limit)
+    const [ sql, params ] = select(this._etable, query || {}, sort, offset, limit)
     const result = await this._connection.query<InferSelectType<Table>>(sql, params)
     return result.rows
   }

--- a/workspaces/persister/src/persister.ts
+++ b/workspaces/persister/src/persister.ts
@@ -3,8 +3,8 @@ import { PGClient } from '@juit/pgproxy-client'
 import { Model } from './model'
 
 import type { PGClientOptions, PGConnection, PGQuery, PGResult, PGTransactionable } from '@juit/pgproxy-client'
+import type { ColumnDefinition } from '@juit/pgproxy-model'
 import type { Registry } from '@juit/pgproxy-types'
-import type { ColumnDefinition } from './model'
 
 /* ========================================================================== *
  * TYPES                                                                      *

--- a/workspaces/persister/src/search.ts
+++ b/workspaces/persister/src/search.ts
@@ -2,206 +2,23 @@ import { escape } from '@juit/pgproxy-client'
 
 import { assert, encodeSchemaAndName } from './utils'
 
-import type { ColumnDefinition, InferSelectType } from './model'
-import type { Persister } from './persister'
+import type { PGQuery } from '@juit/pgproxy-client'
+import type {
+  SearchJoin,
+  SearchJoins,
+  SearchOptions,
+  SearchQuery,
+  SearchResult,
+  SearchResults,
+} from '@juit/pgproxy-model'
+import type { Connection, Persister } from './persister'
 
 /* ========================================================================== *
  * TYPES & INTERFACES                                                         *
  * ========================================================================== */
 
-/* ===== JOINS ============================================================== */
-
 /**
- * Definition for a simple (straight) join in a {@link Search}
- */
-export interface SearchJoin<Schema> {
-  /**
-   * The column in _the search table_ (passed to the constructor of
-   * {@link Search}) referencing the specified `refTable` (defined here).
-   *
-   * ```sql
-   * ... LEFT JOIN "refTable" ON "table"."column" = "refTable"."refColumn"
-   *                                      ^^^^^^
-   * ```
-   */
-  column: string
-  /**
-   * The name of the table to _left join_.
-   *
-   * ```sql
-   * ... LEFT JOIN "refTable" ON "table"."column" = "refTable"."refColumn"
-   *                ^^^^^^^^                         ^^^^^^^^
-   * ```
-   */
-  refTable: string & keyof Schema
-  /**
-   * The column in the `refTable` referenced by the _the search table_.
-   *
-   * ```sql
-   * ... LEFT JOIN "refTable" ON "table"."column" = "refTable"."refColumn"
-   *                                                            ^^^^^^^^^
-   * ```
-   */
-  refColumn: string
-  /**
-   * The column in the referenced table to use as default sort column, when
-   * sorting by this join.
-   */
-  sortColumn?: string
-}
-
-/**
- * Definition for joins in a {@link Search}
- *
- * Each key is the name of the join as it will appear in the results, and the
- * value defines how to perform the join.
- *
- * See {@link StraightJoin} and {@link LinkedJoin} for details on the fields.
- */
-export interface SearchJoins<Schema> {
-  [ key: string ]: SearchJoin<Schema>
-}
-
-/* ===== SEARCH OPTIONS ===================================================== */
-
-/** Internal interface defining operators available to *single values* */
-interface ValueSearchFilter<
-  Schema,
-  Table extends string & keyof Schema,
-> {
-  name: string & keyof Schema[Table]
-  field?: string
-  op?: '=' | '!=' | '>' | '>=' | '<' | '<=' | '~' | 'like' | 'ilike'
-  value: string | number | Date | boolean | null
-}
-
-/** Internal interface defining operators available to *array values* */
-interface ArraySearchFilter<
-  Schema,
-  Table extends string & keyof Schema,
-> {
-  name: string & keyof Schema[Table]
-  field?: string
-  op: 'in' | 'not in'
-  value: (string | number | Date | boolean | null)[]
-}
-
-/** Internal interface defining operators available to *json values* */
-interface JsonSearchFilter<
-  Schema,
-  Table extends string & keyof Schema,
-> {
-  name: string & keyof Schema[Table]
-  field?: never
-  op: '@>' | '<@'
-  value: any
-}
-
-/**
- * A filter for a search that matches a single value
- *
- * - `name` is the column name to filter on
- * - `field` is a field to filter on when the column is a complex type (JSONB)
- * - `op` is the operator to use for the filter (default: `=`)
- * - `value` is the value to filter for
- *
- * All operators are defined as per PostgreSQL documentation, with few notable
- * exceptions:
- *
- * - `~` is an alias to the `ilike` operator
- * - `in` and `not in` are used to match a value against an array of possible
- *   values using the `... = ANY(...)`  or `... != ALL(...)` constructs
- * - `@>` and `<@` will accept single values as well as arrays.
- * - `!=` and `=` will use the PostgreSQL `IS (NOT) DISTINCT FROM` semantics
- *   to properly handle `NULL` comparisons.
- */
-export type SearchFilter<
-  Schema,
-  Table extends string & keyof Schema,
-> = ValueSearchFilter<Schema, Table> | ArraySearchFilter<Schema, Table> | JsonSearchFilter<Schema, Table>
-
-/**
- * Base interface for querying results via our {@link Search}.
- */
-export interface SearchQuery<
-  Schema,
-  Table extends string & keyof Schema,
-  Joins extends SearchJoins<Schema> = {},
-> {
-  /** An optional set of filters to apply */
-  filters?: SearchFilter<Schema, Table>[]
-  /** An optional column to sort by */
-  sort?: string & (keyof Schema[Table] | keyof Joins)
-  /** The order to sort by (if `sort` is specified, default: 'asc') */
-  order?: 'asc' | 'desc'
-  /** An optional full-text search query, available for full-text search */
-  q?: string
-}
-
-/**
- * Full options for querying a limited set of results via our {@link Search}.
- */
-export interface SearchOptions<
-  Schema,
-  Table extends string & keyof Schema,
-  Joins extends SearchJoins<Schema> = {},
-> extends SearchQuery<Schema, Table, Joins> {
-  /** Offset to start returning rows from (default: 0) */
-  offset?: number
-  /** Maximum number of rows to return (default: 20, unlimited if 0) */
-  limit?: number
-}
-
-/**
- * Extra (manual) SQL to further customize our {@link Search} queries.
- */
-export interface SearchExtra {
-  /** Extra `WHERE` clause to add to our search */
-  where: string
-  /** Parameters for the extra `WHERE` clause */
-  params: any[]
-}
-
-/* ===== SEARCH RESULTS ===================================================== */
-
-/** A single search result row (with joins) */
-export type SearchResult<
-  Schema,
-  Table extends string & keyof Schema,
-  Joins extends SearchJoins<Schema> = {},
-> =
-  Schema[Table] extends Record<string, ColumnDefinition> ?
-  // This is the main table's column field
-  InferSelectType<Schema[Table]> & {
-    // For each join, add a field with the joined table's inferred type
-    [ key in keyof Joins ] : Joins[key]['refTable'] extends keyof Schema ?
-      // If the column referencing this join is nullable, the result can be null
-      Schema[Joins[key]['refTable']] extends Record<string, ColumnDefinition> ?
-        Schema[Table][Joins[key]['column']]['isNullable'] extends true ?
-          InferSelectType<Schema[Joins[key]['refTable']]> | null :
-          InferSelectType<Schema[Joins[key]['refTable']]> :
-        // If the joined table isn't a column def, we can't infer anything
-        unknown :
-      // If the table doesn't exist in the schema, we can't infer anything
-      unknown
-  } : never
-
-/** What's being returned by our `search` */
-export interface SearchResults<
-  Schema,
-  Table extends string & keyof Schema,
-  Joins extends SearchJoins<Schema> = {},
-> {
-  /** The total length of all available results (without offset or limit) */
-  total: number
-  /** The lines queried (truncated by offset and limit) */
-  rows: SearchResult<Schema, Table, Joins>[]
-}
-
-/* ===== SEARCH ============================================================= */
-
-/**
- * An object to perform searches on a given table in our {@link Persister}
+ * An object to perform searches on a given table.
  */
 export interface Search<
   Schema,
@@ -214,105 +31,114 @@ export interface Search<
    * This will intrinsically limit the search to 1 result.
    *
    * @param query The query to filter results by
-   * @param extra Optional extra SQL to customize the search
+   * @param where Optional extra SQL `WHERE` clauses to customize the search
    * @returns The first matching result, or `undefined` if no results matched
    */
-  find(query: SearchQuery<Schema, Table, Joins>, extra?: SearchExtra): Promise<SearchResult<Schema, Table, Joins> | undefined>
+  find(query: SearchQuery<Schema, Table, Joins>, where?: PGQuery): Promise<SearchResult<Schema, Table, Joins> | undefined>
 
   /**
    * Return the raw SQL query and parameters for the specified options.
    *
    * @param options The search options to generate SQL for
-   * @param extra Optional extra SQL to customize the search
+   * @param where Optional extra SQL `WHERE` clauses to customize the search
    * @returns A tuple containing the SQL string and its parameters
    */
-  query(options: SearchOptions<Schema, Table, Joins>, extra?: SearchExtra): [ sql: string, params: any[] ]
+  query(options: SearchOptions<Schema, Table, Joins>, where?: PGQuery): [ sql: string, params: any[] ]
 
   /**
    * Perform a search with the specified options.
    *
    * @param options The search options to use
-   * @param extra Optional extra SQL to customize the search
+   * @param where Optional extra SQL `WHERE` clauses to customize the search
    * @returns The search results
    */
-  search(options: SearchOptions<Schema, Table, Joins>, extra?: SearchExtra): Promise<SearchResults<Schema, Table, Joins>>
+  search(options: SearchOptions<Schema, Table, Joins>, where?: PGQuery): Promise<SearchResults<Schema, Table, Joins>>
 }
+
+/**
+ * A query provider for models
+ */
+export type SearchProvider<Schema = any> = Persister<Schema> | Connection<Schema>
 
 /**
  * A constructor for our {@link Search} object
  */
 export interface SearchConstructor {
   /**
-   * Construct a {@link Search} object using the specified {@link Persister},
-   * operating on the specified table.
+   * Construct a {@link Search} object using the specified
+   * {@link SearchProvider} (a `Persister`, `Connection`, ...) operating on the
+   * specified table.
    *
-   * @param persister The {@link Persister} instance to use
+   * @param provider The {@link SearchProvider} instance to use
    * @param table The table to perform searches on
    */
   new<
-    P extends Persister,
-    T extends string & (P extends Persister<infer S> ? keyof S : never),
+    P extends SearchProvider,
+    T extends string & (P extends SearchProvider<infer S> ? keyof S : never),
   >(
-    persister: P,
+    provider: P,
     table: T,
-  ): Search<P extends Persister<infer S> ? S : never, T, {}>;
+  ): Search<P extends SearchProvider<infer S> ? S : never, T, {}>;
 
   /**
-   * Construct a {@link Search} object using the specified {@link Persister},
-   * operating on the specified table, and using the specified full-text search
+   * Construct a {@link Search} object using the specified
+   * {@link SearchProvider} (a `Persister`, `Connection`, ...) operating on the
+   * specified table, and using the specified full-text search
    * column (TSVECTOR) to perform `q` searches.
    *
-   * @param persister The {@link Persister} instance to use
+   * @param provider The {@link SearchProvider} instance to use
    * @param table The table to perform searches on
    * @param fullTextSearchColumn The column to use for full-text searches
    */
   new<
-    P extends Persister,
-    T extends string & (P extends Persister<infer S> ? keyof S : never),
+    P extends SearchProvider,
+    T extends string & (P extends SearchProvider<infer S> ? keyof S : never),
   >(
-    persister: P,
+    provider: P,
     table: T,
     fullTextSearchColumn: string,
-  ): Search<P extends Persister<infer S> ? S : never, T, {}>;
+  ): Search<P extends SearchProvider<infer S> ? S : never, T, {}>;
 
   /**
-   * Construct a {@link Search} object using the specified {@link Persister},
-   * operating on the specified table, joining external tables.
+   * Construct a {@link Search} object using the specified
+   * {@link SearchProvider} (a `Persister`, `Connection`, ...) operating on the
+   * specified table, joining external tables.
    *
-   * @param persister The {@link Persister} instance to use
+   * @param provider The {@link SearchProvider} instance to use
    * @param table The table to perform searches on
    * @param joins The joins to perform
    */
   new<
-    P extends Persister,
-    T extends string & (P extends Persister<infer S> ? keyof S : never),
-    J extends SearchJoins<P extends Persister<infer S> ? S : never>,
+    P extends SearchProvider,
+    T extends string & (P extends SearchProvider<infer S> ? keyof S : never),
+    J extends SearchJoins<P extends SearchProvider<infer S> ? S : never>,
   >(
-    persister: P,
+    provider: P,
     table: T,
     joins: J,
-  ): Search<P extends Persister<infer S> ? S : never, T, J>;
+  ): Search<P extends SearchProvider<infer S> ? S : never, T, J>;
 
   /**
-   * Construct a {@link Search} object using the specified {@link Persister},
-   * operating on the specified table, joining external tables, and using the
-   * specified full-text search column (TSVECTOR) to perform `q` searches.
+   * Construct a {@link Search} object using the specified
+   * {@link SearchProvider} (a `Persister`, `Connection`, ...) operating on the
+   * specified table, joining external tables, and using the specified full-text
+   * search column (TSVECTOR) to perform `q` searches.
    *
-   * @param persister The {@link Persister} instance to use
+   * @param provider The {@link SearchProvider} instance to use
    * @param table The table to perform searches on
    * @param joins The joins to perform
    * @param fullTextSearchColumn The column to use for full-text searches
    */
   new<
-    P extends Persister,
-    T extends string & (P extends Persister<infer S> ? keyof S : never),
-    J extends SearchJoins<P extends Persister<infer S> ? S : never>,
+    P extends SearchProvider,
+    T extends string & (P extends SearchProvider<infer S> ? keyof S : never),
+    J extends SearchJoins<P extends SearchProvider<infer S> ? S : never>,
   >(
-    persister: P,
+    provider: P,
     table: T,
     joins: J,
     fullTextSearchColumn: string,
-  ): Search<P extends Persister<infer S> ? S : never, T, J>;
+  ): Search<P extends SearchProvider<infer S> ? S : never, T, J>;
 }
 
 /* ========================================================================== *
@@ -333,8 +159,8 @@ class SearchImpl<
   Table extends string & keyof Schema,
   Joins extends SearchJoins<Schema> = {},
 > implements Search<Schema, Table, Joins> {
-  /** Our persister instance */
-  #persister: Persister<Schema>
+  /** Our search provider instance */
+  #provider: SearchProvider<Schema>
   /** The escaped table name */
   #eTable: string
   /** The escaped joins */
@@ -342,18 +168,18 @@ class SearchImpl<
   /** The full-text search column (if any) */
   #fullTextSearchColumn: string | undefined
 
-  constructor(persister: Persister<Schema>, table: Table)
-  constructor(persister: Persister<Schema>, table: Table, fullTextSearchColumn: string)
-  constructor(persister: Persister<Schema>, table: Table, joins: Joins)
-  constructor(persister: Persister<Schema>, table: Table, joins: Joins, fullTextSearchColumn: string)
+  constructor(provider: SearchProvider<Schema>, table: Table)
+  constructor(provider: SearchProvider<Schema>, table: Table, fullTextSearchColumn: string)
+  constructor(provider: SearchProvider<Schema>, table: Table, joins: Joins)
+  constructor(provider: SearchProvider<Schema>, table: Table, joins: Joins, fullTextSearchColumn: string)
 
   constructor(
-      persister: Persister<Schema>,
+      provider: SearchProvider<Schema>,
       table: Table,
       joinsOrFullTextSearchColumn?: Joins | string,
       maybeFullTextSearchColumn?: string,
   ) {
-    this.#persister = persister
+    this.#provider = provider
     this.#eTable = encodeSchemaAndName(table)
 
     let joins: Joins = {} as Joins
@@ -381,7 +207,7 @@ class SearchImpl<
   #query(
       count: boolean | 'only',
       options: SearchOptions<Schema, Table, Joins>,
-      extra?: SearchExtra,
+      extra?: PGQuery,
   ): [ sql: string, params: any[] ] {
     const {
       offset = 0,
@@ -403,8 +229,8 @@ class SearchImpl<
     // Extra manual SQL *always* goes FIRST in our WHERE clause, its
     // parameters always start at $1
     if (extra) {
-      where.push(extra.where)
-      params.push(...extra.params)
+      where.push(extra.query)
+      if (extra.params) params.push(...extra.params)
     }
 
     let esearch = '' // falsy!
@@ -545,28 +371,28 @@ class SearchImpl<
     return [ sql, params ]
   }
 
-  query(options: SearchOptions<Schema, Table, Joins>, extra?: SearchExtra): [ sql: string, params: any[] ] {
-    return this.#query(false, options, extra)
+  query(options: SearchOptions<Schema, Table, Joins>, where?: PGQuery): [ sql: string, params: any[] ] {
+    return this.#query(false, options, where)
   }
 
-  async find(options: SearchQuery<Schema, Table, Joins>, extra?: SearchExtra): Promise<SearchResult<Schema, Table, Joins> | undefined> {
-    const [ sql, params ] = this.#query(false, { ...options, offset: 0, limit: 1 }, extra)
+  async find(options: SearchQuery<Schema, Table, Joins>, where?: PGQuery): Promise<SearchResult<Schema, Table, Joins> | undefined> {
+    const [ sql, params ] = this.#query(false, { ...options, offset: 0, limit: 1 }, where)
 
-    const result = await this.#persister.query<{ total?: number, result: string }>(sql, params)
+    const result = await this.#provider.query<{ total?: number, result: string }>(sql, params)
     if (result.rows[0]) return JSON.parse(result.rows[0].result, reviver)
     return undefined
   }
 
-  async search(options: SearchOptions<Schema, Table, Joins>, extra?: SearchExtra): Promise<SearchResults<Schema, Table, Joins>> {
-    const [ sql, params ] = this.#query(true, options, extra)
+  async search(options: SearchOptions<Schema, Table, Joins>, where?: PGQuery): Promise<SearchResults<Schema, Table, Joins>> {
+    const [ sql, params ] = this.#query(true, options, where)
 
-    const result = await this.#persister.query<{ total: number, result: string }>(sql, params).catch((error) => {
+    const result = await this.#provider.query<{ total: number, result: string }>(sql, params).catch((error) => {
       throw new Error(`Error executing search query: ${error.message}`, { cause: { sql, params, error } })
     })
 
     if ((result.rows.length === 0) && ((options.offset || 0) > 0)) {
-      const [ sql, params ] = this.#query('only', { ...options, offset: 0, limit: undefined }, extra)
-      const result = await this.#persister.query<{ total: number }>(sql, params)
+      const [ sql, params ] = this.#query('only', { ...options, offset: 0, limit: undefined }, where)
+      const result = await this.#provider.query<{ total: number }>(sql, params)
       assert(result.rows[0], 'Expected total row in count query')
       const total = Number(result.rows[0].total)
       return { total, rows: [] }

--- a/workspaces/persister/test/03-search.test.ts
+++ b/workspaces/persister/test/03-search.test.ts
@@ -58,6 +58,7 @@ interface Schema {
 
 describe('Search (Query Preparation)', () => {
   const persister: Persister<Schema> = null as any
+
   const joins = {
     sortable: { column: 'sortable_id', refTable: 'sortables', refColumn: 'id', sortColumn: 'sortable_column' },
     unsortable: { column: 'unsortable_id', refTable: 'unsortables', refColumn: 'id' },
@@ -340,7 +341,7 @@ describe('Search (Query Preparation)', () => {
 
   it('should prepare a query with an extra "where" clause', () => {
     check(search.query({ filters: [ { name: 'id', value: 123 } ] }, {
-      where: '"foo" = $1 AND "bar" = $2',
+      query: '"foo" = $1 AND "bar" = $2',
       params: [ 'FOO', 'BAR' ],
     }), `SELECT ((TO_JSONB("public"."main".*) - $3)
              || JSONB_BUILD_OBJECT($4::TEXT, TO_JSONB("__$0001$__"))

--- a/workspaces/persister/test/03-search.test.ts
+++ b/workspaces/persister/test/03-search.test.ts
@@ -174,7 +174,7 @@ describe('Search (Query Preparation)', () => {
   })
 
   it('should throw when a joined field can not be sorted upon', () => {
-    expect(() => search.query({ sort: 'unsortable' }))
+    expect(() => search.query({ sort: 'unsortable' as any }))
         .toThrowError('Sort column for joined field "unsortable" not defined')
   })
 

--- a/workspaces/persister/test/04-search-real.test.ts
+++ b/workspaces/persister/test/04-search-real.test.ts
@@ -5,8 +5,7 @@ import '@juit/pgproxy-client-psql'
 
 import { Persister, Search } from '../src'
 
-
-import type { SearchJoins } from '../src/search'
+import type { SearchJoins } from '@juit/pgproxy-model'
 import type { TestSchema } from './test-schema'
 
 describe('Search (Query Execution)', () => {
@@ -54,6 +53,7 @@ describe('Search (Query Execution)', () => {
 
   it('should return all our result data', async () => {
     const result = await search.search({ limit: 100 })
+
     expect(result).toEqual({
       total: data.length,
       rows: expect.toMatchContents(data),
@@ -523,7 +523,7 @@ describe('Search (Query Execution)', () => {
     const result = await search.search({
       filters: [ { name: 'key', op: 'in', value: [ 'AAAAAA', 'CCCCCC', 'xxxxxx' ] } ],
     }, {
-      where: '"number" < $1 AND "number" > $2',
+      query: '"number" < $1 AND "number" > $2',
       params: [ 1023, 1018 ],
     })
     expect(result).toEqual({

--- a/workspaces/pool/package.json
+++ b/workspaces/pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-pool",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/workspaces/server/package.json
+++ b/workspaces/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/juitnow/juit-pgproxy#readme",
   "dependencies": {
-    "@juit/pgproxy-pool": "1.4.1",
+    "@juit/pgproxy-pool": "1.4.2",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/workspaces/types/package.json
+++ b/workspaces/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-types",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/workspaces/utils/package.json
+++ b/workspaces/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juit/pgproxy-utils",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -43,8 +43,8 @@
     "src/"
   ],
   "dependencies": {
-    "@juit/pgproxy-client": "1.4.1",
-    "@juit/pgproxy-types": "1.4.1",
-    "@plugjs/plug": "^0.6.78"
+    "@juit/pgproxy-client": "1.4.2",
+    "@juit/pgproxy-types": "1.4.2",
+    "@plugjs/plug": "^0.6.79"
   }
 }


### PR DESCRIPTION
Cleanup and reorganize types, by creating a new _types only_ package `@juit/pgproxy-model` containing all required types for shipping to transitive dependencies without importing *any* other package